### PR TITLE
Dreibein in Spezialkisten

### DIFF
--- a/addons/opt_weapons/config.cpp
+++ b/addons/opt_weapons/config.cpp
@@ -1,4 +1,4 @@
-#include "\opt\opt_client\addons\core\macros.hpp"
+﻿#include "\opt\opt_client\addons\core\macros.hpp"
 
 class CfgPatches
 {
@@ -5217,6 +5217,12 @@ class CfgVehicles
 				name = "optic_LRPS_tna_F";
 				count = 50;
 			};
+
+			class _xx_ACE_Tripod
+			{
+				name = "ACE_Tripod";
+				count = 20;
+			};
 		};
 
 		class TransportBackpacks
@@ -6381,6 +6387,12 @@ class CfgVehicles
 			{
 				name = "optic_LRPS_ghex_F";
 				count = 50;
+			};
+
+			class _xx_ACE_Tripod
+			{
+				name = "ACE_Tripod";
+				count = 20;
 			};
 		};
 


### PR DESCRIPTION
- jeweils 20 "SSWT Kit" Dreibein-Stative in die NATO- und CSAT-Spezialkisten gelegt.