### PR TITLE
Sonderfahrzeug Radar Flak die zweite 

### DIFF
--- a/addons/opt_vehicles/uav/config.cpp
+++ b/addons/opt_vehicles/uav/config.cpp
@@ -2,7 +2,7 @@ class CfgPatches
 {
 	class opt_vehicles_uav
 	{
-		units[] = {"OPT_B_UAV_02_F", "OPT_B_UAV_02_light_F", "OPT_B_UAV_02_CAS_F", "OPT_O_UAV_02_F", "OPT_O_UAV_02_light_F", "OPT_O_UAV_02_CAS_F", "OPT_B_UAV_01_F", "OPT_O_UAV_01_F"};
+		units[] = {"OPT_B_UAV_02_F", "OPT_B_UAV_02_light_F", "OPT_B_UAV_02_CAS_F", "OPT_O_UAV_02_F", "OPT_O_UAV_02_light_F", "OPT_O_UAV_02_CAS_F", "OPT_B_UAV_01_F", "OPT_O_UAV_01_F","OPT_B_Radar_System_01_F","OPT_O_Radar_System_02_F"};
 		weapons[] = {};
 		requiredVersion = 0.100000;
 		requiredAddons[] = {"opt_weapons", "opt_characters", "opt_core", "a3_armor_f", "a3_soft_f", "a3_soft_f_mrap_01", "a3_soft_f_mrap_02", "a3_soft_f_mrap_03", "a3_armor_f_panther",
@@ -684,6 +684,248 @@ class CfgVehicles
 					class Narrow : Narrow
 					{
 						visionMode[] = {"Normal", "NVG"};
+					};
+				};
+			};
+		};
+	};
+
+	// Radardrohne NATO
+	class  Radar_System_01_base_F;
+
+	class B_Radar_System_01_F : Radar_System_01_base_F
+	{
+		class Components;
+		class SensorTemplateActiveRadar;
+		class SensorTemplateDataLink;
+		class SensorTemplateMan;
+	};
+
+	class OPT_B_Radar_System_01_F : B_Radar_System_01_F
+	{
+		displayName = "Radarersatz";
+		faction = "OPT_NATO_T";
+
+		class Components: Components 
+		{
+			class SensorsManagerComponent 
+			{
+				class Components 
+				{
+					class ManSensorComponent : SensorTemplateMan 
+					{
+						class AirTarget 
+						{
+							maxRange = 2500;
+							minRange = 2500;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						class GroundTarget 
+						{
+							maxRange = 2500;
+							minRange = 2500;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						typeRecognitionDistance = 3000;
+						angleRangeHorizontal = 360;
+						angleRangeVertical = 180;
+						nightRangeCoef = 1;
+						maxFogSeeThrough= -1;
+						groundNoiseDistanceCoef = -1;
+						maxGroundNoiseDistance = -1;
+						minSpeedThreshold = 0;
+						animDirection = "cannon_barrel";
+					};
+
+					class ActiveRadarSensorComponent: SensorTemplateActiveRadar 
+					{
+						aimDown = -45;
+						class AirTarget 
+						{
+							maxRange = 2500;
+							minRange = 2500;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						allowsMarking = 1;
+						angleRangeHorizontal = 360;
+						angleRangeVertical = 100;
+						animDirection = "";
+						color[] = {0,1,1,1};
+						componentType = "ActiveRadarSensorComponent";
+						groundNoiseDistanceCoef = 0.5;
+						class GroundTarget 
+						{
+							maxRange = 2500;
+							minRange = 2500;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						maxGroundNoiseDistance = 200;
+						maxSpeedThreshold = 27.7778;
+						maxTrackableATL = 1e+010;
+						maxTrackableSpeed = 694.444;
+						minSpeedThreshold = 20.8333;
+						minTrackableATL = -1e+010;
+						minTrackableSpeed = -1e+010;
+						typeRecognitionDistance = 6000;
+					};
+
+					class DataLinkSensorComponent: SensorTemplateDataLink 
+					{
+						aimDown = 0;
+						class AirTarget 
+						{
+							maxRange = 16000;
+							minRange = 16000;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						allowsMarking = 1;
+						angleRangeHorizontal = 360;
+						angleRangeVertical = 360;
+						animDirection = "";
+						color[] = {1,1,1,0};
+						componentType = "DataLinkSensorComponent";
+						groundNoiseDistanceCoef = -1;
+						class GroundTarget 
+						{
+							maxRange = 16000;
+							minRange = 16000;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						maxGroundNoiseDistance = -1;
+						maxSpeedThreshold = 0;
+						maxTrackableATL = 1e+010;
+						maxTrackableSpeed = 1e+010;
+						minSpeedThreshold = 0;
+						minTrackableATL = -1e+010;
+						minTrackableSpeed = -1e+010;
+						typeRecognitionDistance = 0;
+					};
+				};
+			};
+		};
+	};
+
+	// Radardrohne CSAT
+	class  Radar_System_02_base_F;
+
+	class O_Radar_System_02_F : Radar_System_02_base_F
+	{
+		class Components;
+		class SensorTemplateActiveRadar;
+		class SensorTemplateDataLink;
+		class SensorTemplateMan;
+	};
+
+	class OPT_O_Radar_System_02_F : O_Radar_System_02_F
+	{
+		displayName = "Radarersatz";
+		faction = "OPT_CSAT_T";
+
+		class Components: Components 
+		{
+			class SensorsManagerComponent 
+			{
+				class Components 
+				{
+					class ManSensorComponent : SensorTemplateMan 
+					{
+						class AirTarget 
+						{
+							maxRange = 2500;
+							minRange = 2500;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						class GroundTarget 
+						{
+							maxRange = 2500;
+							minRange = 2500;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						typeRecognitionDistance = 3000;
+						angleRangeHorizontal = 360;
+						angleRangeVertical = 180;
+						nightRangeCoef = 1;
+						maxFogSeeThrough= -1;
+						groundNoiseDistanceCoef = -1;
+						maxGroundNoiseDistance = -1;
+						minSpeedThreshold = 0;
+						animDirection = "cannon_barrel";
+					};
+
+					class ActiveRadarSensorComponent: SensorTemplateActiveRadar 
+					{
+						aimDown = -45;
+						class AirTarget 
+						{
+							maxRange = 2500;
+							minRange = 2500;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						allowsMarking = 1;
+						angleRangeHorizontal = 360;
+						angleRangeVertical = 100;
+						animDirection = "";
+						color[] = {0,1,1,1};
+						componentType = "ActiveRadarSensorComponent";
+						groundNoiseDistanceCoef = 0.5;
+						class GroundTarget 
+						{
+							maxRange = 2500;
+							minRange = 2500;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						maxGroundNoiseDistance = 200;
+						maxSpeedThreshold = 27.7778;
+						maxTrackableATL = 1e+010;
+						maxTrackableSpeed = 694.444;
+						minSpeedThreshold = 20.8333;
+						minTrackableATL = -1e+010;
+						minTrackableSpeed = -1e+010;
+						typeRecognitionDistance = 6000;
+					};
+
+					class DataLinkSensorComponent: SensorTemplateDataLink 
+					{
+						aimDown = 0;
+						class AirTarget 
+						{
+							maxRange = 16000;
+							minRange = 16000;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						allowsMarking = 1;
+						angleRangeHorizontal = 360;
+						angleRangeVertical = 360;
+						animDirection = "";
+						color[] = {1,1,1,0};
+						componentType = "DataLinkSensorComponent";
+						groundNoiseDistanceCoef = -1;
+						class GroundTarget 
+						{
+							maxRange = 16000;
+							minRange = 16000;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						maxGroundNoiseDistance = -1;
+						maxSpeedThreshold = 0;
+						maxTrackableATL = 1e+010;
+						maxTrackableSpeed = 1e+010;
+						minSpeedThreshold = 0;
+						minTrackableATL = -1e+010;
+						minTrackableSpeed = -1e+010;
+						typeRecognitionDistance = 0;
 					};
 				};
 			};

--- a/addons/opt_vehicles/unarmed/config.cpp
+++ b/addons/opt_vehicles/unarmed/config.cpp
@@ -702,6 +702,7 @@ class CfgVehicles
 		class Components;
 		class SensorTemplateActiveRadar;
 		class SensorTemplateDataLink;
+		class SensorTemplateMan;
 	};
 
 	class OPT4_B_APC_Tracked_01_AA_ghex_F : OPT_B_APC_Tracked_01_AA_ghex_F
@@ -721,6 +722,14 @@ class CfgVehicles
 	{
 		displayName = "SonderFahrzeug Radarersatz";
 		fuelCapacity = 0; 
+		editorPreview = "\A3\EditorPreviews_F_Sams\Data\Cfgvehicles\B_Radar_System_01_F.jpg";
+		icon = "\A3\Static_F_Sams\Radar_System_01\Data\UI\Radar_System_01_icon_CA.paa";
+		model = "\A3\Static_F_Sams\Radar_System_01\Radar_System_01_F.p3d";
+		hiddenSelections[] = {"camo1","camo2"};
+		hiddenSelectionsMaterials[] = {};
+		hiddenSelectionsTextures[] = {"A3\Static_F_Sams\Radar_System_01\Data\Radar_system_01_mat_01_CO.paa","A3\Static_F_Sams\Radar_System_01\Data\Radar_system_01_mat_02_CO.paa"};
+		hiddenUnderwaterSelections[] = {};
+		hiddenUnderwaterSelectionsTextures[] = {};
 
 		class Components: Components 
 		{
@@ -728,6 +737,33 @@ class CfgVehicles
 			{
 				class Components 
 				{
+					class ManSensorComponent : SensorTemplateMan 
+					{
+						class AirTarget 
+						{
+							maxRange = 2500;
+							minRange = 2500;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						
+						class GroundTarget 
+						{
+							maxRange = 2500;
+							minRange = 2500;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						typeRecognitionDistance = 3000;
+						angleRangeHorizontal = 360;
+						angleRangeVertical = 180;
+						nightRangeCoef = 1;
+						maxFogSeeThrough= -1;
+						groundNoiseDistanceCoef = -1;
+						maxGroundNoiseDistance = -1;
+						minSpeedThreshold = 0;
+						animDirection = "cannon_barrel";
+					};
 					class ActiveRadarSensorComponent: SensorTemplateActiveRadar 
 					{
 						aimDown = -45;
@@ -1116,6 +1152,7 @@ class CfgVehicles
 		class Components;
 		class SensorTemplateActiveRadar;
 		class SensorTemplateDataLink;
+		class SensorTemplateMan;
 		
 	};
 
@@ -1137,6 +1174,14 @@ class CfgVehicles
 		displayName = "SonderFahrzeug Radarersatz";
 		fuelCapacity = 0; 
 		faction = "OPT_CSAT_T";
+		editorPreview = "\A3\EditorPreviews_F_Sams\Data\Cfgvehicles\O_Radar_System_02_F.jpg";
+		icon = "\A3\Static_F_Sams\Radar_System_02\Data\UI\Radar_System_02_icon_CA.paa";
+		model = "\A3\Static_F_Sams\Radar_System_02\Radar_System_02_F.p3d";
+		hiddenSelections[] = {"camo1","camo2"};
+		hiddenSelectionsMaterials[] = {};
+		hiddenSelectionsTextures[] = {"A3\Static_F_Sams\Radar_System_02\Data\Radar_system_02_mat_01_CO.paa","A3\Static_F_Sams\Radar_System_02\Data\Radar_system_02_mat_02_CO.paa"};
+		hiddenUnderwaterSelections[] = {};
+		hiddenUnderwaterSelectionsTextures[] = {};
 
 		class Components: Components 
 		{
@@ -1144,6 +1189,33 @@ class CfgVehicles
 			{
 				class Components 
 				{
+					class ManSensorComponent : SensorTemplateMan 
+					{
+						class AirTarget 
+						{
+							maxRange = 2500;
+							minRange = 2500;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						class GroundTarget 
+						{
+							maxRange = 2500;
+							minRange = 2500;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						typeRecognitionDistance = 3000;
+						angleRangeHorizontal = 360;
+						angleRangeVertical = 180;
+						nightRangeCoef = 1;
+						maxFogSeeThrough= -1;
+						groundNoiseDistanceCoef = -1;
+						maxGroundNoiseDistance = -1;
+						minSpeedThreshold = 0;
+						animDirection = "cannon_barrel";
+					};
+
 					class ActiveRadarSensorComponent: SensorTemplateActiveRadar 
 					{
 						aimDown = -45;

--- a/addons/opt_vehicles/unarmed/config.cpp
+++ b/addons/opt_vehicles/unarmed/config.cpp
@@ -5,9 +5,9 @@ class CfgPatches
 		units[] = {"OPT4_B_MRAP_01_gmg_F","OPT4_B_MRAP_01_gmg_ghex_F", "OPT4_B_MRAP_01_hmg_F","OPT4_B_MRAP_01_hmg_ghex_F", "OPT4_O_MRAP_02_hmg_F", "OPT4_O_T_MRAP_02_hmg_ghex_F", "OPT4_O_MRAP_02_gmg_F", "OPT4_O_T_MRAP_02_gmg_ghex_F", "OPT4_B_MRAP_03_hmg_F", "OPT4_B_MRAP_03_gmg_F",
 				   "OPT4_O_Heli_Attack_02_F", "OPT4_O_Heli_Attack_02_black_F", "OPT4_B_Heli_Attack_01_F", "OPT4_B_Heli_Attack_01_F", "OPT4_B_Heli_Light_01_armed_F", "OPT4_O_Heli_Light_01_armed_F",
 				   "OPT4_O_Heli_light_03_F", " OPT4_O_Heli_light_03_green_F", "OPT4_O_Heli_Light_02_F", "OPT4_O_Heli_Light_02_black_F",
-				   "OPT4_B_APC_Wheeled_01_cannon_F", "OPT4_B_APC_Wheeled_01_cannon_ghex_F", "OPT4_B_APC_Tracked_01_rcws_F","OPT4_B_APC_Tracked_01_rcws_ghex_F", "OPT4_B_APC_Tracked_01_AA_F","OPT_B_APC_Tracked_01_AA_ghex_F", "OPT4_B_MBT_01_cannon_F","OPT4_B_MBT_01_cannon_ghex_F",
+				   "OPT4_B_APC_Wheeled_01_cannon_F", "OPT4_B_APC_Wheeled_01_cannon_ghex_F", "OPT4_B_APC_Tracked_01_rcws_F","OPT4_B_APC_Tracked_01_rcws_ghex_F", "OPT4_B_APC_Tracked_01_AA_F","OPT_B_APC_Tracked_01_AA_ghex_F","OPT_B_APC_Tracked_01_AA_ghex_F2", "OPT4_B_MBT_01_cannon_F","OPT4_B_MBT_01_cannon_ghex_F",
 				   "OPT4_B_MBT_01_TUSK_F","OPT_B_MBT_01_TUSK_ghex_F", "OPT4_B_MBT_01_arty_F","OPT4_B_MBT_01_arty_ghex_F", "OPT4_B_MBT_01_mlrs_F","OPT4_B_MBT_01_mlrs_ghex_F", "OPT4_O_APC_Wheeled_02_rcws_F", "OPT4_O_T_APC_Wheeled_02_rcws_ghex_F", "OPT4_B_APC_tracked_03_cannon_F","OPT4_B_APC_tracked_03_cannon_ghex_F", "OPT4_O_APC_Tracked_02_cannon_F",
-				   "OPT4_O_T_APC_Tracked_02_cannon_ghex_F", "OPT4_O_APC_Tracked_02_AA_F", "OPT4_O_T_APC_Tracked_02_AA_ghex_F", "OPT4_O_MBT_02_cannon_F", "OPT4_O_T_MBT_02_cannon_ghex_F", "OPT4_O_MBT_02_arty_F", "OPT4_O_T_MBT_02_arty_ghex_F",
+				   "OPT4_O_T_APC_Tracked_02_cannon_ghex_F", "OPT4_O_APC_Tracked_02_AA_F", "OPT4_O_T_APC_Tracked_02_AA_ghex_F","OPT4_O_T_APC_Tracked_02_AA_ghex_F2", "OPT4_O_MBT_02_cannon_F", "OPT4_O_T_MBT_02_cannon_ghex_F", "OPT4_O_MBT_02_arty_F", "OPT4_O_T_MBT_02_arty_ghex_F",
 				   "OPT4_O_APC_Wheeled_03_cannon_F","OPT4_O_APC_Wheeled_03_cannon_ghex_F", "OPT4_B_MBT_03_cannon_F","OPT4_B_MBT_03_cannon_ghex_F", "OPT4_B_LSV_01_AT_F","OPT4_B_LSV_01_AT_ghex_F", "OPT4_O_LSV_02_AT_F", "OPT4_O_Truck_02_MRL_F","OPT4_O_LSV_02_AT_GHEX_F"};
 		weapons[] = {};
 		requiredVersion = 0.100000;
@@ -699,10 +699,105 @@ class CfgVehicles
 	{
 		class Turrets;
 		class MainTurret;
+		class Components;
+		class SensorTemplateActiveRadar;
+		class SensorTemplateDataLink;
 	};
 
 	class OPT4_B_APC_Tracked_01_AA_ghex_F : OPT_B_APC_Tracked_01_AA_ghex_F
 	{
+		class Turrets : Turrets
+		{
+			class MainTurret : MainTurret
+			{
+				weapons[] = {};
+				magazines[] = {};
+			};
+		};
+	};
+
+	// Sonderfahrzeug als Radarersatz
+	class OPT4_B_APC_Tracked_01_AA_ghex_F2 : OPT_B_APC_Tracked_01_AA_ghex_F
+	{
+		displayName = "SonderFahrzeug Radarersatz";
+		fuelCapacity = 0; 
+
+		class Components: Components 
+		{
+			class SensorsManagerComponent 
+			{
+				class Components 
+				{
+					class ActiveRadarSensorComponent: SensorTemplateActiveRadar 
+					{
+						aimDown = -45;
+						class AirTarget 
+						{
+							maxRange = 5000;
+							minRange = 5000;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						allowsMarking = 1;
+						angleRangeHorizontal = 360;
+						angleRangeVertical = 100;
+						animDirection = "";
+						color[] = {0,1,1,1};
+						componentType = "ActiveRadarSensorComponent";
+						groundNoiseDistanceCoef = 0.5;
+						class GroundTarget 
+						{
+							maxRange = 5000;
+							minRange = 5000;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						maxGroundNoiseDistance = 200;
+						maxSpeedThreshold = 27.7778;
+						maxTrackableATL = 1e+010;
+						maxTrackableSpeed = 694.444;
+						minSpeedThreshold = 20.8333;
+						minTrackableATL = -1e+010;
+						minTrackableSpeed = -1e+010;
+						typeRecognitionDistance = 6000;
+					};
+					class DataLinkSensorComponent: SensorTemplateDataLink 
+					{
+						aimDown = 0;
+						class AirTarget 
+						{
+							maxRange = 16000;
+							minRange = 16000;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						allowsMarking = 1;
+						angleRangeHorizontal = 360;
+						angleRangeVertical = 360;
+						animDirection = "";
+						color[] = {1,1,1,0};
+						componentType = "DataLinkSensorComponent";
+						groundNoiseDistanceCoef = -1;
+						class GroundTarget 
+						{
+							maxRange = 16000;
+							minRange = 16000;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						maxGroundNoiseDistance = -1;
+						maxSpeedThreshold = 0;
+						maxTrackableATL = 1e+010;
+						maxTrackableSpeed = 1e+010;
+						minSpeedThreshold = 0;
+						minTrackableATL = -1e+010;
+						minTrackableSpeed = -1e+010;
+						typeRecognitionDistance = 0;
+					};
+				};
+			};
+		};
+				
 		class Turrets : Turrets
 		{
 			class MainTurret : MainTurret
@@ -1018,10 +1113,107 @@ class CfgVehicles
 	{
 		class Turrets;
 		class MainTurret;
+		class Components;
+		class SensorTemplateActiveRadar;
+		class SensorTemplateDataLink;
+		
 	};
 
 	class OPT4_O_T_APC_Tracked_02_AA_ghex_F : OPT_O_T_APC_Tracked_02_AA_ghex_F
 	{
+		class Turrets : Turrets
+		{
+			class MainTurret : MainTurret
+			{
+				weapons[] = {};
+				magazines[] = {};
+			};
+		};
+	};
+
+	//Sonderfahrzeug als Radarersatz
+	class OPT4_O_T_APC_Tracked_02_AA_ghex_F2 : OPT_O_T_APC_Tracked_02_AA_ghex_F
+	{
+		displayName = "SonderFahrzeug Radarersatz";
+		fuelCapacity = 0; 
+		faction = "OPT_CSAT_T";
+
+		class Components: Components 
+		{
+			class SensorsManagerComponent 
+			{
+				class Components 
+				{
+					class ActiveRadarSensorComponent: SensorTemplateActiveRadar 
+					{
+						aimDown = -45;
+						class AirTarget 
+						{
+							maxRange = 5000;
+							minRange = 5000;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						allowsMarking = 1;
+						angleRangeHorizontal = 360;
+						angleRangeVertical = 100;
+						animDirection = "";
+						color[] = {0,1,1,1};
+						componentType = "ActiveRadarSensorComponent";
+						groundNoiseDistanceCoef = 0.5;
+						class GroundTarget 
+						{
+							maxRange = 5000;
+							minRange = 5000;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						maxGroundNoiseDistance = 200;
+						maxSpeedThreshold = 27.7778;
+						maxTrackableATL = 1e+010;
+						maxTrackableSpeed = 694.444;
+						minSpeedThreshold = 20.8333;
+						minTrackableATL = -1e+010;
+						minTrackableSpeed = -1e+010;
+						typeRecognitionDistance = 6000;
+					};
+					class DataLinkSensorComponent: SensorTemplateDataLink 
+					{
+						aimDown = 0;
+						class AirTarget 
+						{
+							maxRange = 16000;
+							minRange = 16000;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						allowsMarking = 1;
+						angleRangeHorizontal = 360;
+						angleRangeVertical = 360;
+						animDirection = "";
+						color[] = {1,1,1,0};
+						componentType = "DataLinkSensorComponent";
+						groundNoiseDistanceCoef = -1;
+						class GroundTarget 
+						{
+							maxRange = 16000;
+							minRange = 16000;
+							objectDistanceLimitCoef = -1;
+							viewDistanceLimitCoef = -1;
+						};
+						maxGroundNoiseDistance = -1;
+						maxSpeedThreshold = 0;
+						maxTrackableATL = 1e+010;
+						maxTrackableSpeed = 1e+010;
+						minSpeedThreshold = 0;
+						minTrackableATL = -1e+010;
+						minTrackableSpeed = -1e+010;
+						typeRecognitionDistance = 0;
+					};
+				};
+			};
+		};
+		
 		class Turrets : Turrets
 		{
 			class MainTurret : MainTurret

--- a/addons/opt_vehicles/unarmed/config.cpp
+++ b/addons/opt_vehicles/unarmed/config.cpp
@@ -733,8 +733,8 @@ class CfgVehicles
 						aimDown = -45;
 						class AirTarget 
 						{
-							maxRange = 5000;
-							minRange = 5000;
+							maxRange = 2500;
+							minRange = 2500;
 							objectDistanceLimitCoef = -1;
 							viewDistanceLimitCoef = -1;
 						};
@@ -747,8 +747,8 @@ class CfgVehicles
 						groundNoiseDistanceCoef = 0.5;
 						class GroundTarget 
 						{
-							maxRange = 5000;
-							minRange = 5000;
+							maxRange = 2500;
+							minRange = 2500;
 							objectDistanceLimitCoef = -1;
 							viewDistanceLimitCoef = -1;
 						};
@@ -1149,8 +1149,8 @@ class CfgVehicles
 						aimDown = -45;
 						class AirTarget 
 						{
-							maxRange = 5000;
-							minRange = 5000;
+							maxRange = 2500;
+							minRange = 2500;
 							objectDistanceLimitCoef = -1;
 							viewDistanceLimitCoef = -1;
 						};
@@ -1163,8 +1163,8 @@ class CfgVehicles
 						groundNoiseDistanceCoef = 0.5;
 						class GroundTarget 
 						{
-							maxRange = 5000;
-							minRange = 5000;
+							maxRange = 2500;
+							minRange = 2500;
 							objectDistanceLimitCoef = -1;
 							viewDistanceLimitCoef = -1;
 						};

--- a/mod.cpp
+++ b/mod.cpp
@@ -1,4 +1,4 @@
-name = "OPT Client-Mod v2.9.2";
+name = "OPT Client-Mod v2.9.3";
 picture = "opt4_icon.paa";
 actionName = "Website";
 action = "http://www.operation-pandora.de";


### PR DESCRIPTION
Sonderfahrzeug für Träger mit 2,5KM Aktiv Radar.
Fahrzeug ist Statisch und unbeweglich. 

Löst https://github.com/OperationPandoraTrigger/OPT-Mission/issues/100